### PR TITLE
Add (very short) timeout to Dial with IPv6

### DIFF
--- a/pkg/tracer/offsetguess.go
+++ b/pkg/tracer/offsetguess.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/iovisor/gobpf/elf"
@@ -165,7 +166,7 @@ func tryCurrentOffset(module *elf.Module, mp *elf.Map, status *tcpTracerStatus, 
 
 		conn.Close()
 	} else {
-		conn, err := net.Dial("tcp6", fmt.Sprintf("[%s]:9092", ip))
+		conn, err := net.DialTimeout("tcp6", fmt.Sprintf("[%s]:9092", ip), time.Millisecond)
 		// Since we connect to a random IP, this will most likely fail.
 		// In the unlikely case where it connects successfully, we close
 		// the connection to avoid a leak.


### PR DESCRIPTION
Connecting to a random IPv6 address will most probably not succeed,
but will timeout eventually.

The default timeout is too high and we don't really care about the
connection succeeding or not, we just need to trigger the kprobe.

This adds a timeout of 1 millisecond to the Dial function for IPv6 so
each connection doesn't hang for a long time.

We didn't notice this before because we haven't tried the guessing
program in an IPv6 network.

Depends on #1