### PR TITLE
Assign concrete values to cross-program constants

### DIFF
--- a/pkg/tracer/event_common.go
+++ b/pkg/tracer/event_common.go
@@ -8,10 +8,9 @@ type EventType uint32
 
 // These constants should be in sync with the equivalent definitions in the ebpf program.
 const (
-	_ EventType = iota
-	EventConnect
-	EventAccept
-	EventClose
+	EventConnect EventType = 1
+	EventAccept            = 2
+	EventClose             = 3
 )
 
 func (e EventType) String() string {

--- a/pkg/tracer/offsetguess.go
+++ b/pkg/tracer/offsetguess.go
@@ -33,21 +33,23 @@ const (
 	thresholdInetSock = 2000
 )
 
+// These constants should be in sync with the equivalent definitions in the ebpf program.
 const (
-	stateUninitialized C.__u64 = iota
-	stateChecking              // status set by userspace, waiting for eBPF
-	stateChecked               // status set by eBPF, waiting for userspace
-	stateReady                 // fully initialized, all offset known
+	stateUninitialized C.__u64 = 0
+	stateChecking              = 1 // status set by userspace, waiting for eBPF
+	stateChecked               = 2 // status set by eBPF, waiting for userspace
+	stateReady                 = 3 // fully initialized, all offset known
 )
 
+// These constants should be in sync with the equivalent definitions in the ebpf program.
 const (
-	guessSaddr C.__u64 = iota
-	guessDaddr
-	guessFamily
-	guessSport
-	guessDport
-	guessNetns
-	guessDaddrIPv6
+	guessSaddr     C.__u64 = 0
+	guessDaddr             = 1
+	guessFamily            = 2
+	guessSport             = 3
+	guessDport             = 4
+	guessNetns             = 5
+	guessDaddrIPv6         = 6
 )
 
 const listenIP = "127.0.0.2"


### PR DESCRIPTION
Since it is vital that these constants must match between the go and EBPF programs,
I believe it is clearer to use explicit values 1, 2, etc instead of relying on the iota behaviour,
which is more suitable for situations where the exist value doesn't matter as much as that they all be unique.