### PR TITLE
check_family: Return false when unknown, instead of true

### DIFF
--- a/tcptracer-bpf.c
+++ b/tcptracer-bpf.c
@@ -286,7 +286,7 @@ static bool check_family(struct sock *sk, u16 expected_family) {
 
 	status = bpf_map_lookup_elem(&tcptracer_status, &zero);
 	if (status == NULL || status->state != TCPTRACER_STATE_READY) {
-		return 1;
+		return 0;
 	}
 
 	bpf_probe_read(&family, sizeof(u16), ((char *)sk) + status->offset_family);


### PR DESCRIPTION
This makes no difference in practice since all usages of this function are preceeded by a check
that status is not null and in state READY, but unless I misunderstand the default response
if family can not be determined should be that it does NOT match (so it will be ignored),
not that it does, which would cause code to proceed on a likely incorrect assumption.