### PR TITLE
GC rkt pods after each run

### DIFF
--- a/semaphore.sh
+++ b/semaphore.sh
@@ -77,4 +77,6 @@ for kernel_version in "${kernel_versions[@]}"; do
     if [[ $test_status -ne 0 ]]; then
         exit "$test_status"
     fi
+
+    sudo ./rkt/rkt gc --grace-period=0
 done


### PR DESCRIPTION
So Semaphore doesn't run out of space.