### PR TITLE
offsetguess: fix rare failures on offset guessing

### DIFF
--- a/pkg/tracer/offsetguess.go
+++ b/pkg/tracer/offsetguess.go
@@ -200,7 +200,7 @@ func tryCurrentOffset(module *elf.Module, mp *elf.Map, status *tcpTracerStatus, 
 
 		conn.Close()
 	} else {
-		conn, err := net.DialTimeout("tcp6", fmt.Sprintf("[%s]:9092", ip), time.Millisecond)
+		conn, err := net.DialTimeout("tcp6", fmt.Sprintf("[%s]:9092", ip), 10*time.Millisecond)
 		// Since we connect to a random IP, this will most likely fail.
 		// In the unlikely case where it connects successfully, we close
 		// the connection to avoid a leak.

--- a/pkg/tracer/offsetguess.go
+++ b/pkg/tracer/offsetguess.go
@@ -156,6 +156,21 @@ func htons(a uint16) uint16 {
 	return nativeEndian.Uint16(arr[:])
 }
 
+func generateRandomIPv6Address() (addr [4]uint32) {
+	// multicast (ff00::/8) or link-local (fe80::/10) addresses don't work for
+	// our purposes so let's choose a "random number" for the first 32 bits.
+	//
+	// chosen by fair dice roll.
+	// guaranteed to be random.
+	// https://xkcd.com/221/
+	addr[0] = 0x87586031
+	addr[1] = rand.Uint32()
+	addr[2] = rand.Uint32()
+	addr[3] = rand.Uint32()
+
+	return
+}
+
 // tryCurrentOffset creates a IPv4 or IPv6 connection so the corresponding
 // tcp_v{4,6}_connect kprobes get triggered and save the value at the current
 // offset in the eBPF map
@@ -163,10 +178,7 @@ func tryCurrentOffset(module *elf.Module, mp *elf.Map, status *tcpTracerStatus, 
 	// for ipv6, we don't need the source port because we already guessed
 	// it doing ipv4 connections so we use a random destination address and
 	// try to connect to it
-	expected.daddrIPv6[0] = rand.Uint32()
-	expected.daddrIPv6[1] = rand.Uint32()
-	expected.daddrIPv6[2] = rand.Uint32()
-	expected.daddrIPv6[3] = rand.Uint32()
+	expected.daddrIPv6 = generateRandomIPv6Address()
 
 	ip := ipv6FromUint32Arr(expected.daddrIPv6)
 


### PR DESCRIPTION
### offsetguess: add a longer timeout for tcp6 Dial

In rare cases Go didn't have enough time to actually do a connection
and the 1 ms timeout was triggered leaving the guess offset state
machine in an invalid state.

Give a bit more time to do the connection.

### offsetguess: do not generate invalid IPv6 addresses

Some IPv6 addresses (multicast and link-local) don't result in struct
sock having the address in the correct field, defeating the purpose of
the guessing offsets code.

Don't generate multicast or link-local addresses.