### PR TITLE
tests/Makefile: add build-in-docker target

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,3 +4,12 @@ all: build
 
 build:
 	go build -o tracer tracer.go
+
+build-in-docker:
+	sudo docker build -t "weaveworks/tcptracer-bpf-ci" .
+	sudo docker run \
+		-v $(GOPATH)/src/github.com/weaveworks/tcptracer-bpf:/go/src/github.com/weaveworks/tcptracer-bpf \
+		--env GOPATH=/go \
+		weaveworks/tcptracer-bpf-ci \
+		sh -c 'cd /go/src/github.com/weaveworks/tcptracer-bpf/tests && make'
+	sudo chown $(shell id -u):$(shell id -u) ./tracer


### PR DESCRIPTION
Apparently, my Golang installation on my laptop does not work anymore.
This allows me to still build the tests using docker:

> cd tests ; make build-in-docker

@schu PTAL