### PR TITLE
perf map fixes

### DIFF
--- a/pkg/tracer/tracer_unsupported.go
+++ b/pkg/tracer/tracer_unsupported.go
@@ -12,7 +12,7 @@ func TracerAsset() ([]byte, error) {
 	return nil, fmt.Errorf("not supported on non-Linux systems")
 }
 
-func NewTracer(tcpEventCbV4 func(TcpV4), tcpEventCbV6 func(TcpV6)) (*Tracer, error) {
+func NewTracer(tcpEventCbV4 func(TcpV4), tcpEventCbV6 func(TcpV6), lostCb func(lost uint64)) (*Tracer, error) {
 	return nil, fmt.Errorf("not supported on non-Linux systems")
 }
 

--- a/tests/tracer.go
+++ b/tests/tracer.go
@@ -35,13 +35,18 @@ func tcpEventCbV6(e tracer.TcpV6) {
 	lastTimestampV6 = e.Timestamp
 }
 
+func lostCb(count uint64) {
+	fmt.Printf("ERROR: lost %d events!\n", count)
+	os.Exit(1)
+}
+
 func main() {
 	if len(os.Args) != 1 {
 		fmt.Fprintf(os.Stderr, "Usage: %s\n", os.Args[0])
 		os.Exit(1)
 	}
 
-	t, err := tracer.NewTracer(tcpEventCbV4, tcpEventCbV6)
+	t, err := tracer.NewTracer(tcpEventCbV4, tcpEventCbV6, lostCb)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/vendor/github.com/iovisor/gobpf/elf/elf_unsupported.go
+++ b/vendor/github.com/iovisor/gobpf/elf/elf_unsupported.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 )
 
-func (b *Module) Load() error {
-	return fmt.Errorf("not supported")
-}
-
 // not supported; dummy struct
 type BPFKProbePerf struct{}
+type SectionParams struct{}
+
+func (b *Module) Load(parameters map[string]SectionParams) error {
+	return fmt.Errorf("not supported")
+}
 
 func NewBpfPerfEvent(fileName string) *BPFKProbePerf {
 	// not supported
@@ -22,7 +23,7 @@ func (b *BPFKProbePerf) Load() error {
 	return fmt.Errorf("not supported")
 }
 
-func (b *BPFKProbePerf) PollStart(mapName string, receiverChan chan []byte) {
+func (b *BPFKProbePerf) PollStart(mapName string, receiverChan chan []byte, lostChan chan uint64) {
 	// not supported
 	return
 }

--- a/vendor/github.com/iovisor/gobpf/elf/table.go
+++ b/vendor/github.com/iovisor/gobpf/elf/table.go
@@ -106,3 +106,28 @@ func (b *Module) LookupElement(mp *Map, key, value unsafe.Pointer) error {
 
 	return nil
 }
+
+// DeleteElement deletes the given key in the the map stored in mp.
+// The key is stored in the key unsafe.Pointer.
+func (b *Module) DeleteElement(mp *Map, key unsafe.Pointer) error {
+	uba := C.union_bpf_attr{}
+	value := unsafe.Pointer(nil)
+	C.create_bpf_lookup_elem(
+		C.int(mp.m.fd),
+		key,
+		value,
+		unsafe.Pointer(&uba),
+	)
+	ret, _, err := syscall.Syscall(
+		C.__NR_bpf,
+		C.BPF_MAP_DELETE_ELEM,
+		uintptr(unsafe.Pointer(&uba)),
+		unsafe.Sizeof(uba),
+	)
+
+	if ret != 0 || err != 0 {
+		return fmt.Errorf("unable to delete element: %s", err)
+	}
+
+	return nil
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -5,7 +5,7 @@
 			"importpath": "github.com/iovisor/gobpf/elf",
 			"repository": "https://github.com/iovisor/gobpf",
 			"vcs": "git",
-			"revision": "65e4048660d6c4339ebae113ac55b1af6f01305d",
+			"revision": "23f7ee81c1cc244d16ddc8110c2ec8b8a09d0448",
 			"branch": "master",
 			"path": "/elf",
 			"notests": true


### PR DESCRIPTION
- vendor fixes from gobpf
- tcptracer-bpf: change the size of the ring buffer "maps/tcp_event_ipv4" to 256 pages (1MB)
- tcptracer-bpf: use the go channel to notify lost events

Do we need two different callbacks for IPv4 and IPv6? With the current code, the lostCb could be called from two different go routines in parallel.

Is 1MB a reasonable size for a ring buffer? On my laptop with 4 cpus, that would mean 4MB in total.

Depends on
- [x] https://github.com/iovisor/gobpf/pull/43
- [x] https://github.com/iovisor/gobpf/pull/44
- [x] https://github.com/weaveworks/tcptracer-bpf/pull/38
- [x] https://github.com/weaveworks/tcptracer-bpf/pull/40

Useful for https://github.com/weaveworks/scope/pull/2507