### PR TITLE
separate starting from initialisation

### DIFF
--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -101,15 +101,17 @@ func NewTracer(tcpEventCbV4 func(TcpV4), tcpEventCbV6 func(TcpV6), lostCb func(l
 		}
 	}()
 
-	perfMapIPV4.PollStart()
-	perfMapIPV6.PollStart()
-
 	return &Tracer{
 		m:           m,
 		perfMapIPV4: perfMapIPV4,
 		perfMapIPV6: perfMapIPV6,
 		stopChan:    stopChan,
 	}, nil
+}
+
+func (t *Tracer) Start() {
+	t.perfMapIPV4.PollStart()
+	t.perfMapIPV6.PollStart()
 }
 
 func (t *Tracer) AddFdInstallWatcher(pid uint32) (err error) {

--- a/pkg/tracer/tracer_unsupported.go
+++ b/pkg/tracer/tracer_unsupported.go
@@ -15,12 +15,13 @@ func TracerAsset() ([]byte, error) {
 func NewTracer(tcpEventCbV4 func(TcpV4), tcpEventCbV6 func(TcpV6), lostCb func(lost uint64)) (*Tracer, error) {
 	return nil, fmt.Errorf("not supported on non-Linux systems")
 }
+func (t *Tracer) Start() {
+}
 func (t *Tracer) AddFdInstallWatcher(pid uint32) (err error) {
 	return fmt.Errorf("not supported on non-Linux systems")
 }
 func (t *Tracer) RemoveFdInstallWatcher(pid uint32) (err error) {
 	return fmt.Errorf("not supported on non-Linux systems")
 }
-
 func (t *Tracer) Stop() {
 }

--- a/tests/tracer.go
+++ b/tests/tracer.go
@@ -67,6 +67,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	t.Start()
+
 	for _, p := range strings.Split(watchFdInstallPids, ",") {
 		if p == "" {
 			continue


### PR DESCRIPTION
to address chicken-and-egg initialisation problems, e.g. when the callback functions require access to the tracer, or some other data structure which can only be created post initialisation.

I need this to fix weaveworks/scope#2687.