### PR TITLE
tracer: close channels on Stop()

### DIFF
--- a/vendor/github.com/iovisor/gobpf/elf/elf.go
+++ b/vendor/github.com/iovisor/gobpf/elf/elf.go
@@ -515,6 +515,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 			isCgroupSkb := strings.HasPrefix(secName, "cgroup/skb")
 			isCgroupSock := strings.HasPrefix(secName, "cgroup/sock")
 			isSocketFilter := strings.HasPrefix(secName, "socket")
+			isTracepoint := strings.HasPrefix(secName, "tracepoint/")
 
 			var progType uint32
 			switch {
@@ -528,9 +529,11 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 				progType = uint32(C.BPF_PROG_TYPE_CGROUP_SOCK)
 			case isSocketFilter:
 				progType = uint32(C.BPF_PROG_TYPE_SOCKET_FILTER)
+			case isTracepoint:
+				progType = uint32(C.BPF_PROG_TYPE_TRACEPOINT)
 			}
 
-			if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter {
+			if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint {
 				rdata, err := rsection.Data()
 				if err != nil {
 					return err
@@ -579,6 +582,12 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 						insns: insns,
 						fd:    int(progFd),
 					}
+				case isTracepoint:
+					b.tracepointPrograms[secName] = &TracepointProgram{
+						Name:  secName,
+						insns: insns,
+						fd:    int(progFd),
+					}
 				}
 			}
 		}
@@ -596,6 +605,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 		isCgroupSkb := strings.HasPrefix(secName, "cgroup/skb")
 		isCgroupSock := strings.HasPrefix(secName, "cgroup/sock")
 		isSocketFilter := strings.HasPrefix(secName, "socket")
+		isTracepoint := strings.HasPrefix(secName, "tracepoint/")
 
 		var progType uint32
 		switch {
@@ -609,9 +619,11 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 			progType = uint32(C.BPF_PROG_TYPE_CGROUP_SOCK)
 		case isSocketFilter:
 			progType = uint32(C.BPF_PROG_TYPE_SOCKET_FILTER)
+		case isTracepoint:
+			progType = uint32(C.BPF_PROG_TYPE_TRACEPOINT)
 		}
 
-		if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter {
+		if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint {
 			data, err := section.Data()
 			if err != nil {
 				return err
@@ -651,6 +663,12 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 				}
 			case isSocketFilter:
 				b.socketFilters[secName] = &SocketFilter{
+					Name:  secName,
+					insns: insns,
+					fd:    int(progFd),
+				}
+			case isTracepoint:
+				b.tracepointPrograms[secName] = &TracepointProgram{
 					Name:  secName,
 					insns: insns,
 					fd:    int(progFd),

--- a/vendor/github.com/iovisor/gobpf/elf/perf.go
+++ b/vendor/github.com/iovisor/gobpf/elf/perf.go
@@ -109,7 +109,7 @@ type PerfMap struct {
 	pageCount    int
 	receiverChan chan []byte
 	lostChan     chan uint64
-	pollStop     chan bool
+	pollStop     chan struct{}
 	timestamp    func(*[]byte) uint64
 }
 
@@ -132,7 +132,7 @@ func InitPerfMap(b *Module, mapName string, receiverChan chan []byte, lostChan c
 		pageCount:    m.pageCount,
 		receiverChan: receiverChan,
 		lostChan:     lostChan,
-		pollStop:     make(chan bool),
+		pollStop:     make(chan struct{}),
 	}, nil
 }
 
@@ -241,7 +241,7 @@ func (pm *PerfMap) PollStart() {
 // PollStop stops the goroutine that polls the perf event map. Make
 // sure to close the receiverChan only *after* calling PollStop.
 func (pm *PerfMap) PollStop() {
-	pm.pollStop <- true
+	close(pm.pollStop)
 }
 
 func perfEventPoll(fds []C.int) error {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -5,7 +5,7 @@
 			"importpath": "github.com/iovisor/gobpf/elf",
 			"repository": "https://github.com/iovisor/gobpf",
 			"vcs": "git",
-			"revision": "51b4a5bc15ab504f9efb7702591ae04bc6c6f068",
+			"revision": "e373dcc735cc7f683407fc56f5186a12869b5e1c",
 			"branch": "master",
 			"path": "/elf",
 			"notests": true
@@ -14,7 +14,7 @@
 			"importpath": "github.com/iovisor/gobpf/pkg/bpffs",
 			"repository": "https://github.com/iovisor/gobpf",
 			"vcs": "git",
-			"revision": "51b4a5bc15ab504f9efb7702591ae04bc6c6f068",
+			"revision": "e373dcc735cc7f683407fc56f5186a12869b5e1c",
 			"branch": "master",
 			"path": "/pkg/bpffs",
 			"notests": true
@@ -23,7 +23,7 @@
 			"importpath": "github.com/iovisor/gobpf/pkg/cpuonline",
 			"repository": "https://github.com/iovisor/gobpf",
 			"vcs": "git",
-			"revision": "51b4a5bc15ab504f9efb7702591ae04bc6c6f068",
+			"revision": "e373dcc735cc7f683407fc56f5186a12869b5e1c",
 			"branch": "master",
 			"path": "/pkg/cpuonline",
 			"notests": true


### PR DESCRIPTION
PerfMap's PollStop() documentation says the channel should be closed
after calling PollStop():
https://github.com/iovisor/gobpf/blob/d0a3e1b/elf/perf.go#L241-L242

This is solving a leaking go routine issue in Scope:
https://github.com/weaveworks/scope/pull/2735#issuecomment-320988997

-----

/cc @iaguis @2opremio @schu 