### PR TITLE
vendor: update gobpf

### DIFF
--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -79,10 +79,19 @@ func NewTracer(cb Callback) (*Tracer, error) {
 		for {
 			select {
 			case <-stopChan:
+				// On stop, stopChan will be closed but the other channels will
+				// also be closed shortly after. The select{} has no priorities,
+				// therefore, the "ok" value must be checked below.
 				return
-			case data := <-channelV4:
+			case data, ok := <-channelV4:
+				if !ok {
+					return // see explanation above
+				}
 				cb.TCPEventV4(tcpV4ToGo(&data))
-			case lost := <-lostChanV4:
+			case lost, ok := <-lostChanV4:
+				if !ok {
+					return // see explanation above
+				}
 				cb.LostV4(lost)
 			}
 		}
@@ -93,9 +102,15 @@ func NewTracer(cb Callback) (*Tracer, error) {
 			select {
 			case <-stopChan:
 				return
-			case data := <-channelV6:
+			case data, ok := <-channelV6:
+				if !ok {
+					return // see explanation above
+				}
 				cb.TCPEventV6(tcpV6ToGo(&data))
-			case lost := <-lostChanV6:
+			case lost, ok := <-lostChanV6:
+				if !ok {
+					return // see explanation above
+				}
 				cb.LostV6(lost)
 			}
 		}

--- a/vendor/github.com/iovisor/gobpf/elf/elf.go
+++ b/vendor/github.com/iovisor/gobpf/elf/elf.go
@@ -515,6 +515,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 			isCgroupSkb := strings.HasPrefix(secName, "cgroup/skb")
 			isCgroupSock := strings.HasPrefix(secName, "cgroup/sock")
 			isSocketFilter := strings.HasPrefix(secName, "socket")
+			isTracepoint := strings.HasPrefix(secName, "tracepoint/")
 
 			var progType uint32
 			switch {
@@ -528,9 +529,11 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 				progType = uint32(C.BPF_PROG_TYPE_CGROUP_SOCK)
 			case isSocketFilter:
 				progType = uint32(C.BPF_PROG_TYPE_SOCKET_FILTER)
+			case isTracepoint:
+				progType = uint32(C.BPF_PROG_TYPE_TRACEPOINT)
 			}
 
-			if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter {
+			if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint {
 				rdata, err := rsection.Data()
 				if err != nil {
 					return err
@@ -579,6 +582,12 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 						insns: insns,
 						fd:    int(progFd),
 					}
+				case isTracepoint:
+					b.tracepointPrograms[secName] = &TracepointProgram{
+						Name:  secName,
+						insns: insns,
+						fd:    int(progFd),
+					}
 				}
 			}
 		}
@@ -596,6 +605,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 		isCgroupSkb := strings.HasPrefix(secName, "cgroup/skb")
 		isCgroupSock := strings.HasPrefix(secName, "cgroup/sock")
 		isSocketFilter := strings.HasPrefix(secName, "socket")
+		isTracepoint := strings.HasPrefix(secName, "tracepoint/")
 
 		var progType uint32
 		switch {
@@ -609,9 +619,11 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 			progType = uint32(C.BPF_PROG_TYPE_CGROUP_SOCK)
 		case isSocketFilter:
 			progType = uint32(C.BPF_PROG_TYPE_SOCKET_FILTER)
+		case isTracepoint:
+			progType = uint32(C.BPF_PROG_TYPE_TRACEPOINT)
 		}
 
-		if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter {
+		if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint {
 			data, err := section.Data()
 			if err != nil {
 				return err
@@ -651,6 +663,12 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 				}
 			case isSocketFilter:
 				b.socketFilters[secName] = &SocketFilter{
+					Name:  secName,
+					insns: insns,
+					fd:    int(progFd),
+				}
+			case isTracepoint:
+				b.tracepointPrograms[secName] = &TracepointProgram{
 					Name:  secName,
 					insns: insns,
 					fd:    int(progFd),

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -5,7 +5,7 @@
 			"importpath": "github.com/iovisor/gobpf/elf",
 			"repository": "https://github.com/iovisor/gobpf",
 			"vcs": "git",
-			"revision": "51b4a5bc15ab504f9efb7702591ae04bc6c6f068",
+			"revision": "f53889884f5cb2c5c3c644a56467002232d208e9",
 			"branch": "master",
 			"path": "/elf",
 			"notests": true
@@ -14,7 +14,7 @@
 			"importpath": "github.com/iovisor/gobpf/pkg/bpffs",
 			"repository": "https://github.com/iovisor/gobpf",
 			"vcs": "git",
-			"revision": "51b4a5bc15ab504f9efb7702591ae04bc6c6f068",
+			"revision": "f53889884f5cb2c5c3c644a56467002232d208e9",
 			"branch": "master",
 			"path": "/pkg/bpffs",
 			"notests": true
@@ -23,7 +23,7 @@
 			"importpath": "github.com/iovisor/gobpf/pkg/cpuonline",
 			"repository": "https://github.com/iovisor/gobpf",
 			"vcs": "git",
-			"revision": "51b4a5bc15ab504f9efb7702591ae04bc6c6f068",
+			"revision": "f53889884f5cb2c5c3c644a56467002232d208e9",
 			"branch": "master",
 			"path": "/pkg/cpuonline",
 			"notests": true


### PR DESCRIPTION
Includes the gobpf changes:
- https://github.com/iovisor/gobpf/pull/70
- https://github.com/iovisor/gobpf/pull/71

Basically, this closes Go channels on the sender side (in gobpf) rather than on the receiver side (in tcptracer-bpf).

Supersedes https://github.com/weaveworks/tcptracer-bpf/pull/49
Needed for https://github.com/weaveworks/scope/pull/2735

/cc @iaguis @2opremio @schu
