### PR TITLE
tcptracer-bpf.c: ignore enum-conversion warning

### DIFF
--- a/tcptracer-bpf.c
+++ b/tcptracer-bpf.c
@@ -12,6 +12,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-compare"
 #pragma clang diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
+#pragma clang diagnostic ignored "-Wenum-conversion"
 #include <net/sock.h>
 #pragma clang diagnostic pop
 #include <net/inet_sock.h>


### PR DESCRIPTION
A kernel update in the fedora image used to build tcptracer-bpf causes a
enum-conversion warning which makes the build fail because we pass
`-Werror` to the compiler.

Ignore that warning.