### PR TITLE
offsetguess: increase threshold

### DIFF
--- a/pkg/tracer/offsetguess.go
+++ b/pkg/tracer/offsetguess.go
@@ -28,7 +28,7 @@ type tcpTracerStatus C.struct_tcptracer_status_t
 const (
 	// When reading kernel structs at different offsets, don't go over that
 	// limit. This is an arbitrary choice to avoid infinite loops.
-	threshold = 200
+	threshold = 400
 
 	// The source port is much further away in the inet sock.
 	thresholdInetSock = 2000


### PR DESCRIPTION
We've found that [Google COS images in GCE were failing when trying to
guess netns](https://github.com/weaveworks/scope/issues/2796#issuecomment-358786806). This was because the field is beyond the threshold (one
byte away, actually).

Increase the threshold to 400 to have some breathing room in case more
fields are added to the structs we guess. Offset guessing is done only
once at the beggining and is quite fast, so there's no appreciable loss
of performance.

See
https://github.com/weaveworks/scope/issues/2796#issuecomment-360759884
for an longer explanation.