### PR TITLE
semaphore: update longterm kernels to latest patch version

### DIFF
--- a/semaphore.sh
+++ b/semaphore.sh
@@ -19,8 +19,8 @@ set -o pipefail
 # Currently we test on Linux version
 # 4.4 - the longterm release used in Amazon Linux
 # 4.9 - the latest stable release
-readonly kernel_versions=("4.4.45" "4.9.6")
-readonly rkt_version="1.26.0"
+readonly kernel_versions=("4.4.114" "4.9.79")
+readonly rkt_version="1.29.0"
 
 if [[ ! -f "./rkt/rkt" ]] \
     || [[ ! "$(./rkt/rkt version | awk '/rkt Version/{print $3}')" == "${rkt_version}" ]]; then


### PR DESCRIPTION
Also, update the rkt version used to v1.29.