### PR TITLE
semaphore: update longterm kernels to newer patch version

### DIFF
--- a/semaphore.sh
+++ b/semaphore.sh
@@ -19,8 +19,8 @@ set -o pipefail
 # Currently we test on Linux version
 # 4.4 - the longterm release used in Amazon Linux
 # 4.9 - the latest stable release
-readonly kernel_versions=("4.4.114" "4.9.79")
-readonly rkt_version="1.29.0"
+readonly kernel_versions=("4.4.129" "4.9.96")
+readonly rkt_version="1.30.0"
 
 if [[ ! -f "./rkt/rkt" ]] \
     || [[ ! "$(./rkt/rkt version | awk '/rkt Version/{print $3}')" == "${rkt_version}" ]]; then

--- a/tools/test
+++ b/tools/test
@@ -109,7 +109,7 @@ run_test() {
         ) | paste -s -d, -)
         local output
         output=$(mktemp "$coverdir/unit.XXXXXXXXXX")
-        local GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}" -coverprofile=$output -coverpkg=$COVERPKGS)
+        local GO_TEST_ARGS_RUN=("${GO_TEST_ARGS[@]}" "-coverprofile=$output" "-coverpkg=$COVERPKGS")
     fi
 
     local START


### PR DESCRIPTION
Also, update the rkt version used to v1.30.