### PR TITLE
Adding missing linux header

### DIFF
--- a/pkg/tracer/event.go
+++ b/pkg/tracer/event.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package tracer
 
 import (


### PR DESCRIPTION
tcptracer-bpf is missing a linux header in event.go that blocks development on non-linux machines. Adding this is desirable so that repositories using tcptracer-bpf can be tested (though not integration tested) on non-linux machines.