### PR TITLE
update to 4ece6c5 of iovisor to pull in iovisor/gobpf#139

### DIFF
--- a/vendor/github.com/iovisor/gobpf/elf/elf.go
+++ b/vendor/github.com/iovisor/gobpf/elf/elf.go
@@ -50,29 +50,18 @@ import (
 #include <sys/socket.h>
 #include <linux/unistd.h>
 #include "include/bpf.h"
+#include "include/bpf_map.h"
 #include <poll.h>
 #include <linux/perf_event.h>
 #include <sys/resource.h>
-
-// from https://github.com/safchain/goebpf
-// Apache License, Version 2.0
-
-#define BUF_SIZE_MAP_NS 256
-
-typedef struct bpf_map_def {
-  unsigned int type;
-  unsigned int key_size;
-  unsigned int value_size;
-  unsigned int max_entries;
-  unsigned int map_flags;
-  unsigned int pinning;
-  char namespace[BUF_SIZE_MAP_NS];
-} bpf_map_def;
 
 typedef struct bpf_map {
 	int         fd;
 	bpf_map_def def;
 } bpf_map;
+
+// from https://github.com/safchain/goebpf
+// Apache License, Version 2.0
 
 extern int bpf_pin_object(int fd, const char *pathname);
 
@@ -157,6 +146,7 @@ static bpf_map *bpf_load_map(bpf_map_def *map_def, const char *path)
 		// TODO to be implemented
 		return 0;
 	case 2: // PIN_GLOBAL_NS
+	case 3: // PIN_CUSTOM_NS
 		if (stat(path, &st) == 0) {
 			ret = get_pinned_obj_fd(path);
 			if (ret < 0) {
@@ -262,7 +252,17 @@ static int perf_event_open_map(int pid, int cpu, int group_fd, unsigned long fla
 */
 import "C"
 
-const useCurrentKernelVersion = 0xFFFFFFFE
+const (
+	useCurrentKernelVersion = 0xFFFFFFFE
+
+	// Object pin settings should correspond to those of other projects, e.g.:
+	// https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git/tree/include/bpf_elf.h#n25
+	// Also it should be self-consistent with `elf/include/bpf.h` in the same repository.
+	PIN_NONE      = 0
+	PIN_OBJECT_NS = 1
+	PIN_GLOBAL_NS = 2
+	PIN_CUSTOM_NS = 3
+)
 
 // Based on https://github.com/safchain/goebpf
 // Apache License
@@ -288,39 +288,69 @@ func elfReadVersion(file *elf.File) (uint32, error) {
 			return 0, errors.New("version is not a __u32")
 		}
 		version := *(*C.uint32_t)(unsafe.Pointer(&data[0]))
-		if err != nil {
-			return 0, err
-		}
 		return uint32(version), nil
 	}
 	return 0, nil
 }
 
-func prepareBPFFS(namespace, name string) (string, error) {
-	err := bpffs.Mount()
-	if err != nil {
+func createPinPath(path string) (string, error) {
+	if err := bpffs.Mount(); err != nil {
 		return "", err
 	}
-	mapPath := filepath.Join(BPFFSPath, namespace, BPFDirGlobals, name)
-	err = os.MkdirAll(filepath.Dir(mapPath), syscall.S_IRWXU)
-	if err != nil {
-		return "", fmt.Errorf("error creating map directory %q: %v", filepath.Dir(mapPath), err)
+	if err := os.MkdirAll(filepath.Dir(path), syscall.S_IRWXU); err != nil {
+		return "", fmt.Errorf("error creating map directory %q: %v", filepath.Dir(path), err)
+	}
+	return path, nil
+}
+
+func validateMapPath(path string) bool {
+	if !strings.HasPrefix(path, BPFFSPath) {
+		return false
+	}
+
+	return filepath.Clean(path) == path
+}
+
+func getMapNamespace(mapDef *C.bpf_map_def) string {
+	namespacePtr := &mapDef.namespace[0]
+	return C.GoStringN(namespacePtr, C.int(C.strnlen(namespacePtr, C.BUF_SIZE_MAP_NS)))
+}
+
+func getMapPath(mapDef *C.bpf_map_def, mapName, pinPath string) (string, error) {
+	var mapPath string
+	switch mapDef.pinning {
+	case PIN_OBJECT_NS:
+		return "", fmt.Errorf("not implemented yet")
+	case PIN_GLOBAL_NS:
+		namespace := getMapNamespace(mapDef)
+		if namespace == "" {
+			return "", fmt.Errorf("map %q has empty namespace", mapName)
+		}
+		mapPath = filepath.Join(BPFFSPath, namespace, BPFDirGlobals, mapName)
+	case PIN_CUSTOM_NS:
+		if pinPath == "" {
+			return "", fmt.Errorf("no pin path given for map %q with PIN_CUSTOM_NS", mapName)
+		}
+		mapPath = filepath.Join(BPFFSPath, pinPath)
+	default:
+		// map is not pinned
+		return "", nil
 	}
 	return mapPath, nil
 }
 
-func validMapNamespace(namespaceRaw *C.char) (string, error) {
-	namespace := C.GoStringN(namespaceRaw, C.int(C.strnlen(namespaceRaw, C.BUF_SIZE_MAP_NS)))
-	if namespace == "" || namespace == "." || namespace == ".." {
-		return "", fmt.Errorf("namespace must not be %q", namespace)
+func createMapPath(mapDef *C.bpf_map_def, mapName string, params SectionParams) (string, error) {
+	mapPath, err := getMapPath(mapDef, mapName, params.PinPath)
+	if err != nil || mapPath == "" {
+		return "", err
 	}
-	if strings.Contains(namespace, "/") {
-		return "", fmt.Errorf("no '/' allowed in namespace")
+	if !validateMapPath(mapPath) {
+		return "", fmt.Errorf("invalid path %q", mapPath)
 	}
-	return namespace, nil
+	return createPinPath(mapPath)
 }
 
-func elfReadMaps(file *elf.File) (map[string]*Map, error) {
+func elfReadMaps(file *elf.File, params map[string]SectionParams) (map[string]*Map, error) {
 	maps := make(map[string]*Map)
 	for _, section := range file.Sections {
 		if !strings.HasPrefix(section.Name, "maps/") {
@@ -339,21 +369,12 @@ func elfReadMaps(file *elf.File) (map[string]*Map, error) {
 
 		mapDef := (*C.bpf_map_def)(unsafe.Pointer(&data[0]))
 
-		var mapPathC *C.char
-		if mapDef.pinning > 0 {
-			namespace, err := validMapNamespace(&mapDef.namespace[0])
-			if err != nil {
-				return nil, err
-			}
-			mapPath, err := prepareBPFFS(namespace, name)
-			if err != nil {
-				return nil, fmt.Errorf("error preparing bpf fs: %v", err)
-			}
-			mapPathC = C.CString(mapPath)
-			defer C.free(unsafe.Pointer(mapPathC))
-		} else {
-			mapPathC = nil
+		mapPath, err := createMapPath(mapDef, name, params[section.Name])
+		if err != nil {
+			return nil, err
 		}
+		mapPathC := C.CString(mapPath)
+		defer C.free(unsafe.Pointer(mapPathC))
 
 		cm, err := C.bpf_load_map(mapDef, mapPathC)
 		if cm == nil {
@@ -419,7 +440,12 @@ func (b *Module) relocate(data []byte, rdata []byte) error {
 
 		rinsn := (*C.struct_bpf_insn)(unsafe.Pointer(&rdata[offset]))
 		if rinsn.code != (C.BPF_LD | C.BPF_IMM | C.BPF_DW) {
-			return errors.New("invalid relocation")
+			symbolSec := b.file.Sections[symbol.Section]
+
+			return fmt.Errorf("invalid relocation: insn code=%#x, symbol name=%s\nsymbol section: Name=%s, Type=%s, Flags=%s",
+				*(*C.uchar)(unsafe.Pointer(&rinsn.code)), symbol.Name,
+				symbolSec.Name, symbolSec.Type.String(), symbolSec.Flags.String(),
+			)
 		}
 
 		symbolSec := b.file.Sections[symbol.Section]
@@ -442,6 +468,7 @@ func (b *Module) relocate(data []byte, rdata []byte) error {
 type SectionParams struct {
 	PerfRingBufferPageCount   int
 	SkipPerfMapInitialization bool
+	PinPath                   string // path to be pinned, relative to "/sys/fs/bpf"
 }
 
 // Load loads the BPF programs and BPF maps in the module. Each ELF section
@@ -481,7 +508,7 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 		}
 	}
 
-	maps, err := elfReadMaps(b.file)
+	maps, err := elfReadMaps(b.file, parameters)
 	if err != nil {
 		return err
 	}
@@ -516,6 +543,8 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 			isCgroupSock := strings.HasPrefix(secName, "cgroup/sock")
 			isSocketFilter := strings.HasPrefix(secName, "socket")
 			isTracepoint := strings.HasPrefix(secName, "tracepoint/")
+			isSchedCls := strings.HasPrefix(secName, "sched_cls/")
+			isSchedAct := strings.HasPrefix(secName, "sched_act/")
 
 			var progType uint32
 			switch {
@@ -531,9 +560,13 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 				progType = uint32(C.BPF_PROG_TYPE_SOCKET_FILTER)
 			case isTracepoint:
 				progType = uint32(C.BPF_PROG_TYPE_TRACEPOINT)
+			case isSchedCls:
+				progType = uint32(C.BPF_PROG_TYPE_SCHED_CLS)
+			case isSchedAct:
+				progType = uint32(C.BPF_PROG_TYPE_SCHED_ACT)
 			}
 
-			if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint {
+			if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint || isSchedCls || isSchedAct {
 				rdata, err := rsection.Data()
 				if err != nil {
 					return err
@@ -588,6 +621,14 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 						insns: insns,
 						fd:    int(progFd),
 					}
+				case isSchedCls:
+					fallthrough
+				case isSchedAct:
+					b.schedPrograms[secName] = &SchedProgram{
+						Name:  secName,
+						insns: insns,
+						fd:    int(progFd),
+					}
 				}
 			}
 		}
@@ -606,6 +647,8 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 		isCgroupSock := strings.HasPrefix(secName, "cgroup/sock")
 		isSocketFilter := strings.HasPrefix(secName, "socket")
 		isTracepoint := strings.HasPrefix(secName, "tracepoint/")
+		isSchedCls := strings.HasPrefix(secName, "sched_cls/")
+		isSchedAct := strings.HasPrefix(secName, "sched_act/")
 
 		var progType uint32
 		switch {
@@ -621,9 +664,13 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 			progType = uint32(C.BPF_PROG_TYPE_SOCKET_FILTER)
 		case isTracepoint:
 			progType = uint32(C.BPF_PROG_TYPE_TRACEPOINT)
+		case isSchedCls:
+			progType = uint32(C.BPF_PROG_TYPE_SCHED_CLS)
+		case isSchedAct:
+			progType = uint32(C.BPF_PROG_TYPE_SCHED_ACT)
 		}
 
-		if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint {
+		if isKprobe || isKretprobe || isCgroupSkb || isCgroupSock || isSocketFilter || isTracepoint || isSchedCls || isSchedAct {
 			data, err := section.Data()
 			if err != nil {
 				return err
@@ -673,6 +720,14 @@ func (b *Module) Load(parameters map[string]SectionParams) error {
 					insns: insns,
 					fd:    int(progFd),
 				}
+			case isSchedCls:
+				fallthrough
+			case isSchedAct:
+				b.schedPrograms[secName] = &SchedProgram{
+					Name:  secName,
+					insns: insns,
+					fd:    int(progFd),
+				}
 			}
 		}
 	}
@@ -695,7 +750,7 @@ func (b *Module) initializePerfMaps(parameters map[string]SectionParams) error {
 				continue
 			}
 			if params.PerfRingBufferPageCount > 0 {
-				if params.PerfRingBufferPageCount <= 0 || (params.PerfRingBufferPageCount&(params.PerfRingBufferPageCount-1)) != 0 {
+				if (params.PerfRingBufferPageCount & (params.PerfRingBufferPageCount - 1)) != 0 {
 					return fmt.Errorf("number of pages (%d) must be stricly positive and a power of 2", params.PerfRingBufferPageCount)
 				}
 				b.maps[name].pageCount = params.PerfRingBufferPageCount

--- a/vendor/github.com/iovisor/gobpf/elf/include/bpf.h
+++ b/vendor/github.com/iovisor/gobpf/elf/include/bpf.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
 /* Copyright (c) 2011-2014 PLUMgrid, http://plumgrid.com
  *
  * This program is free software; you can redistribute it and/or
@@ -16,7 +17,7 @@
 #define BPF_ALU64	0x07	/* alu mode in double word width */
 
 /* ld/ldx fields */
-#define BPF_DW		0x18	/* double word */
+#define BPF_DW		0x18	/* double word (64-bit) */
 #define BPF_XADD	0xc0	/* exclusive add */
 
 /* alu/jmp fields */
@@ -30,9 +31,14 @@
 #define BPF_FROM_LE	BPF_TO_LE
 #define BPF_FROM_BE	BPF_TO_BE
 
+/* jmp encodings */
 #define BPF_JNE		0x50	/* jump != */
+#define BPF_JLT		0xa0	/* LT is unsigned, '<' */
+#define BPF_JLE		0xb0	/* LE is unsigned, '<=' */
 #define BPF_JSGT	0x60	/* SGT is signed '>', GT in x86 */
 #define BPF_JSGE	0x70	/* SGE is signed '>=', GE in x86 */
+#define BPF_JSLT	0xc0	/* SLT is signed, '<' */
+#define BPF_JSLE	0xd0	/* SLE is signed, '<=' */
 #define BPF_CALL	0x80	/* function call */
 #define BPF_EXIT	0x90	/* function return */
 
@@ -63,6 +69,12 @@ struct bpf_insn {
 	__s32	imm;		/* signed immediate constant */
 };
 
+/* Key of an a BPF_MAP_TYPE_LPM_TRIE entry */
+struct bpf_lpm_trie_key {
+	__u32	prefixlen;	/* up to 32 for AF_INET, 128 for AF_INET6 */
+	__u8	data[0];	/* Arbitrary size */
+};
+
 /* BPF syscall commands, see bpf(2) man-page for details. */
 enum bpf_cmd {
 	BPF_MAP_CREATE,
@@ -75,6 +87,14 @@ enum bpf_cmd {
 	BPF_OBJ_GET,
 	BPF_PROG_ATTACH,
 	BPF_PROG_DETACH,
+	BPF_PROG_TEST_RUN,
+	BPF_PROG_GET_NEXT_ID,
+	BPF_MAP_GET_NEXT_ID,
+	BPF_PROG_GET_FD_BY_ID,
+	BPF_MAP_GET_FD_BY_ID,
+	BPF_OBJ_GET_INFO_BY_FD,
+	BPF_PROG_QUERY,
+	BPF_RAW_TRACEPOINT_OPEN,
 };
 
 enum bpf_map_type {
@@ -89,6 +109,12 @@ enum bpf_map_type {
 	BPF_MAP_TYPE_CGROUP_ARRAY,
 	BPF_MAP_TYPE_LRU_HASH,
 	BPF_MAP_TYPE_LRU_PERCPU_HASH,
+	BPF_MAP_TYPE_LPM_TRIE,
+	BPF_MAP_TYPE_ARRAY_OF_MAPS,
+	BPF_MAP_TYPE_HASH_OF_MAPS,
+	BPF_MAP_TYPE_DEVMAP,
+	BPF_MAP_TYPE_SOCKMAP,
+	BPF_MAP_TYPE_CPUMAP,
 };
 
 enum bpf_prog_type {
@@ -105,24 +131,97 @@ enum bpf_prog_type {
 	BPF_PROG_TYPE_LWT_IN,
 	BPF_PROG_TYPE_LWT_OUT,
 	BPF_PROG_TYPE_LWT_XMIT,
+	BPF_PROG_TYPE_SOCK_OPS,
+	BPF_PROG_TYPE_SK_SKB,
+	BPF_PROG_TYPE_CGROUP_DEVICE,
+	BPF_PROG_TYPE_SK_MSG,
+	BPF_PROG_TYPE_RAW_TRACEPOINT,
+	BPF_PROG_TYPE_CGROUP_SOCK_ADDR,
 };
 
 enum bpf_attach_type {
 	BPF_CGROUP_INET_INGRESS,
 	BPF_CGROUP_INET_EGRESS,
 	BPF_CGROUP_INET_SOCK_CREATE,
+	BPF_CGROUP_SOCK_OPS,
+	BPF_SK_SKB_STREAM_PARSER,
+	BPF_SK_SKB_STREAM_VERDICT,
+	BPF_CGROUP_DEVICE,
+	BPF_SK_MSG_VERDICT,
+	BPF_CGROUP_INET4_BIND,
+	BPF_CGROUP_INET6_BIND,
+	BPF_CGROUP_INET4_CONNECT,
+	BPF_CGROUP_INET6_CONNECT,
+	BPF_CGROUP_INET4_POST_BIND,
+	BPF_CGROUP_INET6_POST_BIND,
 	__MAX_BPF_ATTACH_TYPE
 };
 
 #define MAX_BPF_ATTACH_TYPE __MAX_BPF_ATTACH_TYPE
 
+/* cgroup-bpf attach flags used in BPF_PROG_ATTACH command
+ *
+ * NONE(default): No further bpf programs allowed in the subtree.
+ *
+ * BPF_F_ALLOW_OVERRIDE: If a sub-cgroup installs some bpf program,
+ * the program in this cgroup yields to sub-cgroup program.
+ *
+ * BPF_F_ALLOW_MULTI: If a sub-cgroup installs some bpf program,
+ * that cgroup program gets run in addition to the program in this cgroup.
+ *
+ * Only one program is allowed to be attached to a cgroup with
+ * NONE or BPF_F_ALLOW_OVERRIDE flag.
+ * Attaching another program on top of NONE or BPF_F_ALLOW_OVERRIDE will
+ * release old program and attach the new one. Attach flags has to match.
+ *
+ * Multiple programs are allowed to be attached to a cgroup with
+ * BPF_F_ALLOW_MULTI flag. They are executed in FIFO order
+ * (those that were attached first, run first)
+ * The programs of sub-cgroup are executed first, then programs of
+ * this cgroup and then programs of parent cgroup.
+ * When children program makes decision (like picking TCP CA or sock bind)
+ * parent program has a chance to override it.
+ *
+ * A cgroup with MULTI or OVERRIDE flag allows any attach flags in sub-cgroups.
+ * A cgroup with NONE doesn't allow any programs in sub-cgroups.
+ * Ex1:
+ * cgrp1 (MULTI progs A, B) ->
+ *    cgrp2 (OVERRIDE prog C) ->
+ *      cgrp3 (MULTI prog D) ->
+ *        cgrp4 (OVERRIDE prog E) ->
+ *          cgrp5 (NONE prog F)
+ * the event in cgrp5 triggers execution of F,D,A,B in that order.
+ * if prog F is detached, the execution is E,D,A,B
+ * if prog F and D are detached, the execution is E,A,B
+ * if prog F, E and D are detached, the execution is C,A,B
+ *
+ * All eligible programs are executed regardless of return code from
+ * earlier programs.
+ */
+#define BPF_F_ALLOW_OVERRIDE	(1U << 0)
+#define BPF_F_ALLOW_MULTI	(1U << 1)
+
+/* If BPF_F_STRICT_ALIGNMENT is used in BPF_PROG_LOAD command, the
+ * verifier will perform strict alignment checking as if the kernel
+ * has been built with CONFIG_EFFICIENT_UNALIGNED_ACCESS not set,
+ * and NET_IP_ALIGN defined to 2.
+ */
+#define BPF_F_STRICT_ALIGNMENT	(1U << 0)
+
+/* when bpf_ldimm64->src_reg == BPF_PSEUDO_MAP_FD, bpf_ldimm64->imm == fd */
 #define BPF_PSEUDO_MAP_FD	1
+
+/* when bpf_call->src_reg == BPF_PSEUDO_CALL, bpf_call->imm == pc-relative
+ * offset to another bpf function
+ */
+#define BPF_PSEUDO_CALL		1
 
 /* flags for BPF_MAP_UPDATE_ELEM command */
 #define BPF_ANY		0 /* create new element or update existing */
 #define BPF_NOEXIST	1 /* create new element if it didn't exist */
 #define BPF_EXIST	2 /* update existing element */
 
+/* flags for BPF_MAP_CREATE command */
 #define BPF_F_NO_PREALLOC	(1U << 0)
 /* Instead of having one common LRU list in the
  * BPF_MAP_TYPE_LRU_[PERCPU_]HASH map, use a percpu LRU list
@@ -131,6 +230,39 @@ enum bpf_attach_type {
  * across different LRU lists.
  */
 #define BPF_F_NO_COMMON_LRU	(1U << 1)
+/* Specify numa node during map creation */
+#define BPF_F_NUMA_NODE		(1U << 2)
+
+/* flags for BPF_PROG_QUERY */
+#define BPF_F_QUERY_EFFECTIVE	(1U << 0)
+
+#define BPF_OBJ_NAME_LEN 16U
+
+/* Flags for accessing BPF object */
+#define BPF_F_RDONLY		(1U << 3)
+#define BPF_F_WRONLY		(1U << 4)
+
+/* Flag for stack_map, store build_id+offset instead of pointer */
+#define BPF_F_STACK_BUILD_ID	(1U << 5)
+
+enum bpf_stack_build_id_status {
+	/* user space need an empty entry to identify end of a trace */
+	BPF_STACK_BUILD_ID_EMPTY = 0,
+	/* with valid build_id and offset */
+	BPF_STACK_BUILD_ID_VALID = 1,
+	/* couldn't get build_id, fallback to ip */
+	BPF_STACK_BUILD_ID_IP = 2,
+};
+
+#define BPF_BUILD_ID_SIZE 20
+struct bpf_stack_build_id {
+	__s32		status;
+	unsigned char	build_id[BPF_BUILD_ID_SIZE];
+	union {
+		__u64	offset;
+		__u64	ip;
+	};
+};
 
 union bpf_attr {
 	struct { /* anonymous struct used by BPF_MAP_CREATE command */
@@ -138,7 +270,15 @@ union bpf_attr {
 		__u32	key_size;	/* size of key in bytes */
 		__u32	value_size;	/* size of value in bytes */
 		__u32	max_entries;	/* max number of entries in a map */
-		__u32	map_flags;	/* prealloc or not */
+		__u32	map_flags;	/* BPF_MAP_CREATE related
+					 * flags defined above.
+					 */
+		__u32	inner_map_fd;	/* fd pointing to the inner map */
+		__u32	numa_node;	/* numa node (effective only if
+					 * BPF_F_NUMA_NODE is set).
+					 */
+		char	map_name[BPF_OBJ_NAME_LEN];
+		__u32	map_ifindex;	/* ifindex of netdev to create on */
 	};
 
 	struct { /* anonymous struct used by BPF_MAP_*_ELEM commands */
@@ -160,18 +300,69 @@ union bpf_attr {
 		__u32		log_size;	/* size of user buffer */
 		__aligned_u64	log_buf;	/* user supplied buffer */
 		__u32		kern_version;	/* checked when prog_type=kprobe */
+		__u32		prog_flags;
+		char		prog_name[BPF_OBJ_NAME_LEN];
+		__u32		prog_ifindex;	/* ifindex of netdev to prep for */
+		/* For some prog types expected attach type must be known at
+		 * load time to verify attach type specific parts of prog
+		 * (context accesses, allowed helpers, etc).
+		 */
+		__u32		expected_attach_type;
 	};
 
 	struct { /* anonymous struct used by BPF_OBJ_* commands */
 		__aligned_u64	pathname;
 		__u32		bpf_fd;
+		__u32		file_flags;
 	};
 
 	struct { /* anonymous struct used by BPF_PROG_ATTACH/DETACH commands */
 		__u32		target_fd;	/* container object to attach to */
 		__u32		attach_bpf_fd;	/* eBPF program to attach */
 		__u32		attach_type;
+		__u32		attach_flags;
 	};
+
+	struct { /* anonymous struct used by BPF_PROG_TEST_RUN command */
+		__u32		prog_fd;
+		__u32		retval;
+		__u32		data_size_in;
+		__u32		data_size_out;
+		__aligned_u64	data_in;
+		__aligned_u64	data_out;
+		__u32		repeat;
+		__u32		duration;
+	} test;
+
+	struct { /* anonymous struct used by BPF_*_GET_*_ID */
+		union {
+			__u32		start_id;
+			__u32		prog_id;
+			__u32		map_id;
+		};
+		__u32		next_id;
+		__u32		open_flags;
+	};
+
+	struct { /* anonymous struct used by BPF_OBJ_GET_INFO_BY_FD */
+		__u32		bpf_fd;
+		__u32		info_len;
+		__aligned_u64	info;
+	} info;
+
+	struct { /* anonymous struct used by BPF_PROG_QUERY command */
+		__u32		target_fd;	/* container object to query */
+		__u32		attach_type;
+		__u32		query_flags;
+		__u32		attach_flags;
+		__aligned_u64	prog_ids;
+		__u32		prog_cnt;
+	} query;
+
+	struct {
+		__u64 name;
+		__u32 prog_fd;
+	} raw_tracepoint;
 } __attribute__((aligned(8)));
 
 /* BPF helper function descriptions:
@@ -235,7 +426,7 @@ union bpf_attr {
  *     jump into another BPF program
  *     @ctx: context pointer passed to next program
  *     @prog_array_map: pointer to map which type is BPF_MAP_TYPE_PROG_ARRAY
- *     @index: index inside array that selects specific program to run
+ *     @index: 32-bit index inside array that selects specific program to run
  *     Return: 0 on success or negative error
  *
  * int bpf_clone_redirect(skb, ifindex, flags)
@@ -276,26 +467,40 @@ union bpf_attr {
  *     @flags: room for future extensions
  *     Return: 0 on success or negative error
  *
- * u64 bpf_perf_event_read(&map, index)
- *     Return: Number events read or error code
+ * u64 bpf_perf_event_read(map, flags)
+ *     read perf event counter value
+ *     @map: pointer to perf_event_array map
+ *     @flags: index of event in the map or bitmask flags
+ *     Return: value of perf event counter read or error code
  *
  * int bpf_redirect(ifindex, flags)
  *     redirect to another netdev
  *     @ifindex: ifindex of the net device
- *     @flags: bit 0 - if set, redirect to ingress instead of egress
- *             other bits - reserved
- *     Return: TC_ACT_REDIRECT
+ *     @flags:
+ *	  cls_bpf:
+ *          bit 0 - if set, redirect to ingress instead of egress
+ *          other bits - reserved
+ *	  xdp_bpf:
+ *	    all bits - reserved
+ *     Return: cls_bpf: TC_ACT_REDIRECT on success or TC_ACT_SHOT on error
+ *	       xdp_bfp: XDP_REDIRECT on success or XDP_ABORT on error
+ * int bpf_redirect_map(map, key, flags)
+ *     redirect to endpoint in map
+ *     @map: pointer to dev map
+ *     @key: index in map to lookup
+ *     @flags: --
+ *     Return: XDP_REDIRECT on success or XDP_ABORT on error
  *
  * u32 bpf_get_route_realm(skb)
  *     retrieve a dst's tclassid
  *     @skb: pointer to skb
  *     Return: realm if != 0
  *
- * int bpf_perf_event_output(ctx, map, index, data, size)
+ * int bpf_perf_event_output(ctx, map, flags, data, size)
  *     output perf raw sample
  *     @ctx: struct pt_regs*
  *     @map: pointer to perf_event_array map
- *     @index: index of event in the map
+ *     @flags: index of event in the map or bitmask flags
  *     @data: data on stack to be output as raw data
  *     @size: size of data
  *     Return: 0 on success or negative error
@@ -430,6 +635,126 @@ union bpf_attr {
  *     @xdp_md: pointer to xdp_md
  *     @delta: An positive/negative integer to be added to xdp_md.data
  *     Return: 0 on success or negative on error
+ *
+ * int bpf_probe_read_str(void *dst, int size, const void *unsafe_ptr)
+ *     Copy a NUL terminated string from unsafe address. In case the string
+ *     length is smaller than size, the target is not padded with further NUL
+ *     bytes. In case the string length is larger than size, just count-1
+ *     bytes are copied and the last byte is set to NUL.
+ *     @dst: destination address
+ *     @size: maximum number of bytes to copy, including the trailing NUL
+ *     @unsafe_ptr: unsafe address
+ *     Return:
+ *       > 0 length of the string including the trailing NUL on success
+ *       < 0 error
+ *
+ * u64 bpf_get_socket_cookie(skb)
+ *     Get the cookie for the socket stored inside sk_buff.
+ *     @skb: pointer to skb
+ *     Return: 8 Bytes non-decreasing number on success or 0 if the socket
+ *     field is missing inside sk_buff
+ *
+ * u32 bpf_get_socket_uid(skb)
+ *     Get the owner uid of the socket stored inside sk_buff.
+ *     @skb: pointer to skb
+ *     Return: uid of the socket owner on success or overflowuid if failed.
+ *
+ * u32 bpf_set_hash(skb, hash)
+ *     Set full skb->hash.
+ *     @skb: pointer to skb
+ *     @hash: hash to set
+ *
+ * int bpf_setsockopt(bpf_socket, level, optname, optval, optlen)
+ *     Calls setsockopt. Not all opts are available, only those with
+ *     integer optvals plus TCP_CONGESTION.
+ *     Supported levels: SOL_SOCKET and IPPROTO_TCP
+ *     @bpf_socket: pointer to bpf_socket
+ *     @level: SOL_SOCKET or IPPROTO_TCP
+ *     @optname: option name
+ *     @optval: pointer to option value
+ *     @optlen: length of optval in bytes
+ *     Return: 0 or negative error
+ *
+ * int bpf_getsockopt(bpf_socket, level, optname, optval, optlen)
+ *     Calls getsockopt. Not all opts are available.
+ *     Supported levels: IPPROTO_TCP
+ *     @bpf_socket: pointer to bpf_socket
+ *     @level: IPPROTO_TCP
+ *     @optname: option name
+ *     @optval: pointer to option value
+ *     @optlen: length of optval in bytes
+ *     Return: 0 or negative error
+ *
+ * int bpf_sock_ops_cb_flags_set(bpf_sock_ops, flags)
+ *     Set callback flags for sock_ops
+ *     @bpf_sock_ops: pointer to bpf_sock_ops_kern struct
+ *     @flags: flags value
+ *     Return: 0 for no error
+ *             -EINVAL if there is no full tcp socket
+ *             bits in flags that are not supported by current kernel
+ *
+ * int bpf_skb_adjust_room(skb, len_diff, mode, flags)
+ *     Grow or shrink room in sk_buff.
+ *     @skb: pointer to skb
+ *     @len_diff: (signed) amount of room to grow/shrink
+ *     @mode: operation mode (enum bpf_adj_room_mode)
+ *     @flags: reserved for future use
+ *     Return: 0 on success or negative error code
+ *
+ * int bpf_sk_redirect_map(map, key, flags)
+ *     Redirect skb to a sock in map using key as a lookup key for the
+ *     sock in map.
+ *     @map: pointer to sockmap
+ *     @key: key to lookup sock in map
+ *     @flags: reserved for future use
+ *     Return: SK_PASS
+ *
+ * int bpf_sock_map_update(skops, map, key, flags)
+ *	@skops: pointer to bpf_sock_ops
+ *	@map: pointer to sockmap to update
+ *	@key: key to insert/update sock in map
+ *	@flags: same flags as map update elem
+ *
+ * int bpf_xdp_adjust_meta(xdp_md, delta)
+ *     Adjust the xdp_md.data_meta by delta
+ *     @xdp_md: pointer to xdp_md
+ *     @delta: An positive/negative integer to be added to xdp_md.data_meta
+ *     Return: 0 on success or negative on error
+ *
+ * int bpf_perf_event_read_value(map, flags, buf, buf_size)
+ *     read perf event counter value and perf event enabled/running time
+ *     @map: pointer to perf_event_array map
+ *     @flags: index of event in the map or bitmask flags
+ *     @buf: buf to fill
+ *     @buf_size: size of the buf
+ *     Return: 0 on success or negative error code
+ *
+ * int bpf_perf_prog_read_value(ctx, buf, buf_size)
+ *     read perf prog attached perf event counter and enabled/running time
+ *     @ctx: pointer to ctx
+ *     @buf: buf to fill
+ *     @buf_size: size of the buf
+ *     Return : 0 on success or negative error code
+ *
+ * int bpf_override_return(pt_regs, rc)
+ *	@pt_regs: pointer to struct pt_regs
+ *	@rc: the return value to set
+ *
+ * int bpf_msg_redirect_map(map, key, flags)
+ *     Redirect msg to a sock in map using key as a lookup key for the
+ *     sock in map.
+ *     @map: pointer to sockmap
+ *     @key: key to lookup sock in map
+ *     @flags: reserved for future use
+ *     Return: SK_PASS
+ *
+ * int bpf_bind(ctx, addr, addr_len)
+ *     Bind socket to address. Only binding to IP is supported, no port can be
+ *     set in addr.
+ *     @ctx: pointer to context of type bpf_sock_addr
+ *     @addr: pointer to struct sockaddr to bind socket to
+ *     @addr_len: length of sockaddr structure
+ *     Return: 0 on success or negative error code
  */
 #define __BPF_FUNC_MAPPER(FN)		\
 	FN(unspec),			\
@@ -476,7 +801,27 @@ union bpf_attr {
 	FN(set_hash_invalid),		\
 	FN(get_numa_node_id),		\
 	FN(skb_change_head),		\
-	FN(xdp_adjust_head),
+	FN(xdp_adjust_head),		\
+	FN(probe_read_str),		\
+	FN(get_socket_cookie),		\
+	FN(get_socket_uid),		\
+	FN(set_hash),			\
+	FN(setsockopt),			\
+	FN(skb_adjust_room),		\
+	FN(redirect_map),		\
+	FN(sk_redirect_map),		\
+	FN(sock_map_update),		\
+	FN(xdp_adjust_meta),		\
+	FN(perf_event_read_value),	\
+	FN(perf_prog_read_value),	\
+	FN(getsockopt),			\
+	FN(override_return),		\
+	FN(sock_ops_cb_flags_set),	\
+	FN(msg_redirect_map),		\
+	FN(msg_apply_bytes),		\
+	FN(msg_cork_bytes),		\
+	FN(msg_pull_data),		\
+	FN(bind),
 
 /* integer value in 'imm' field of BPF_CALL instruction selects which helper
  * function eBPF program intends to call
@@ -502,6 +847,7 @@ enum bpf_func_id {
 /* BPF_FUNC_l4_csum_replace flags. */
 #define BPF_F_PSEUDO_HDR		(1ULL << 4)
 #define BPF_F_MARK_MANGLED_0		(1ULL << 5)
+#define BPF_F_MARK_ENFORCE		(1ULL << 6)
 
 /* BPF_FUNC_clone_redirect and BPF_FUNC_redirect flags. */
 #define BPF_F_INGRESS			(1ULL << 0)
@@ -518,12 +864,20 @@ enum bpf_func_id {
 /* BPF_FUNC_skb_set_tunnel_key flags. */
 #define BPF_F_ZERO_CSUM_TX		(1ULL << 1)
 #define BPF_F_DONT_FRAGMENT		(1ULL << 2)
+#define BPF_F_SEQ_NUMBER		(1ULL << 3)
 
-/* BPF_FUNC_perf_event_output and BPF_FUNC_perf_event_read flags. */
+/* BPF_FUNC_perf_event_output, BPF_FUNC_perf_event_read and
+ * BPF_FUNC_perf_event_read_value flags.
+ */
 #define BPF_F_INDEX_MASK		0xffffffffULL
 #define BPF_F_CURRENT_CPU		BPF_F_INDEX_MASK
 /* BPF_FUNC_perf_event_output for sk_buff input context. */
 #define BPF_F_CTXLEN_MASK		(0xfffffULL << 32)
+
+/* Mode for BPF_FUNC_skb_adjust_room helper. */
+enum bpf_adj_room_mode {
+	BPF_ADJ_ROOM_NET,
+};
 
 /* user accessible mirror of in-kernel sk_buff.
  * new fields can only be added to the end of this structure
@@ -546,6 +900,19 @@ struct __sk_buff {
 	__u32 tc_classid;
 	__u32 data;
 	__u32 data_end;
+	__u32 napi_id;
+
+	/* Accessed by BPF_PROG_TYPE_sk_skb types from here to ... */
+	__u32 family;
+	__u32 remote_ip4;	/* Stored in network byte order */
+	__u32 local_ip4;	/* Stored in network byte order */
+	__u32 remote_ip6[4];	/* Stored in network byte order */
+	__u32 local_ip6[4];	/* Stored in network byte order */
+	__u32 remote_port;	/* Stored in network byte order */
+	__u32 local_port;	/* stored in host byte order */
+	/* ... here. */
+
+	__u32 data_meta;
 };
 
 struct bpf_tunnel_key {
@@ -581,20 +948,32 @@ struct bpf_sock {
 	__u32 family;
 	__u32 type;
 	__u32 protocol;
+	__u32 mark;
+	__u32 priority;
+	__u32 src_ip4;		/* Allows 1,2,4-byte read.
+				 * Stored in network byte order.
+				 */
+	__u32 src_ip6[4];	/* Allows 1,2,4-byte read.
+				 * Stored in network byte order.
+				 */
+	__u32 src_port;		/* Allows 4-byte read.
+				 * Stored in host byte order
+				 */
 };
 
 #define XDP_PACKET_HEADROOM 256
 
 /* User return codes for XDP prog type.
  * A valid XDP program must return one of these defined values. All other
- * return codes are reserved for future use. Unknown return codes will result
- * in packet drop.
+ * return codes are reserved for future use. Unknown return codes will
+ * result in packet drops and a warning via bpf_warn_invalid_xdp_action().
  */
 enum xdp_action {
 	XDP_ABORTED = 0,
 	XDP_DROP,
 	XDP_PASS,
 	XDP_TX,
+	XDP_REDIRECT,
 };
 
 /* user accessible metadata for XDP packet hook
@@ -603,6 +982,236 @@ enum xdp_action {
 struct xdp_md {
 	__u32 data;
 	__u32 data_end;
+	__u32 data_meta;
+	/* Below access go through struct xdp_rxq_info */
+	__u32 ingress_ifindex; /* rxq->dev->ifindex */
+	__u32 rx_queue_index;  /* rxq->queue_index  */
+};
+
+enum sk_action {
+	SK_DROP = 0,
+	SK_PASS,
+};
+
+/* user accessible metadata for SK_MSG packet hook, new fields must
+ * be added to the end of this structure
+ */
+struct sk_msg_md {
+	void *data;
+	void *data_end;
+};
+
+#define BPF_TAG_SIZE	8
+
+struct bpf_prog_info {
+	__u32 type;
+	__u32 id;
+	__u8  tag[BPF_TAG_SIZE];
+	__u32 jited_prog_len;
+	__u32 xlated_prog_len;
+	__aligned_u64 jited_prog_insns;
+	__aligned_u64 xlated_prog_insns;
+	__u64 load_time;	/* ns since boottime */
+	__u32 created_by_uid;
+	__u32 nr_map_ids;
+	__aligned_u64 map_ids;
+	char name[BPF_OBJ_NAME_LEN];
+	__u32 ifindex;
+	__u32 :32;
+	__u64 netns_dev;
+	__u64 netns_ino;
+} __attribute__((aligned(8)));
+
+struct bpf_map_info {
+	__u32 type;
+	__u32 id;
+	__u32 key_size;
+	__u32 value_size;
+	__u32 max_entries;
+	__u32 map_flags;
+	char  name[BPF_OBJ_NAME_LEN];
+	__u32 ifindex;
+	__u32 :32;
+	__u64 netns_dev;
+	__u64 netns_ino;
+} __attribute__((aligned(8)));
+
+/* User bpf_sock_addr struct to access socket fields and sockaddr struct passed
+ * by user and intended to be used by socket (e.g. to bind to, depends on
+ * attach attach type).
+ */
+struct bpf_sock_addr {
+	__u32 user_family;	/* Allows 4-byte read, but no write. */
+	__u32 user_ip4;		/* Allows 1,2,4-byte read and 4-byte write.
+				 * Stored in network byte order.
+				 */
+	__u32 user_ip6[4];	/* Allows 1,2,4-byte read an 4-byte write.
+				 * Stored in network byte order.
+				 */
+	__u32 user_port;	/* Allows 4-byte read and write.
+				 * Stored in network byte order
+				 */
+	__u32 family;		/* Allows 4-byte read, but no write */
+	__u32 type;		/* Allows 4-byte read, but no write */
+	__u32 protocol;		/* Allows 4-byte read, but no write */
+};
+
+/* User bpf_sock_ops struct to access socket values and specify request ops
+ * and their replies.
+ * Some of this fields are in network (bigendian) byte order and may need
+ * to be converted before use (bpf_ntohl() defined in samples/bpf/bpf_endian.h).
+ * New fields can only be added at the end of this structure
+ */
+struct bpf_sock_ops {
+	__u32 op;
+	union {
+		__u32 args[4];		/* Optionally passed to bpf program */
+		__u32 reply;		/* Returned by bpf program	    */
+		__u32 replylong[4];	/* Optionally returned by bpf prog  */
+	};
+	__u32 family;
+	__u32 remote_ip4;	/* Stored in network byte order */
+	__u32 local_ip4;	/* Stored in network byte order */
+	__u32 remote_ip6[4];	/* Stored in network byte order */
+	__u32 local_ip6[4];	/* Stored in network byte order */
+	__u32 remote_port;	/* Stored in network byte order */
+	__u32 local_port;	/* stored in host byte order */
+	__u32 is_fullsock;	/* Some TCP fields are only valid if
+				 * there is a full socket. If not, the
+				 * fields read as zero.
+				 */
+	__u32 snd_cwnd;
+	__u32 srtt_us;		/* Averaged RTT << 3 in usecs */
+	__u32 bpf_sock_ops_cb_flags; /* flags defined in uapi/linux/tcp.h */
+	__u32 state;
+	__u32 rtt_min;
+	__u32 snd_ssthresh;
+	__u32 rcv_nxt;
+	__u32 snd_nxt;
+	__u32 snd_una;
+	__u32 mss_cache;
+	__u32 ecn_flags;
+	__u32 rate_delivered;
+	__u32 rate_interval_us;
+	__u32 packets_out;
+	__u32 retrans_out;
+	__u32 total_retrans;
+	__u32 segs_in;
+	__u32 data_segs_in;
+	__u32 segs_out;
+	__u32 data_segs_out;
+	__u32 lost_out;
+	__u32 sacked_out;
+	__u32 sk_txhash;
+	__u64 bytes_received;
+	__u64 bytes_acked;
+};
+
+/* Definitions for bpf_sock_ops_cb_flags */
+#define BPF_SOCK_OPS_RTO_CB_FLAG	(1<<0)
+#define BPF_SOCK_OPS_RETRANS_CB_FLAG	(1<<1)
+#define BPF_SOCK_OPS_STATE_CB_FLAG	(1<<2)
+#define BPF_SOCK_OPS_ALL_CB_FLAGS       0x7		/* Mask of all currently
+							 * supported cb flags
+							 */
+
+/* List of known BPF sock_ops operators.
+ * New entries can only be added at the end
+ */
+enum {
+	BPF_SOCK_OPS_VOID,
+	BPF_SOCK_OPS_TIMEOUT_INIT,	/* Should return SYN-RTO value to use or
+					 * -1 if default value should be used
+					 */
+	BPF_SOCK_OPS_RWND_INIT,		/* Should return initial advertized
+					 * window (in packets) or -1 if default
+					 * value should be used
+					 */
+	BPF_SOCK_OPS_TCP_CONNECT_CB,	/* Calls BPF program right before an
+					 * active connection is initialized
+					 */
+	BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB,	/* Calls BPF program when an
+						 * active connection is
+						 * established
+						 */
+	BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB,	/* Calls BPF program when a
+						 * passive connection is
+						 * established
+						 */
+	BPF_SOCK_OPS_NEEDS_ECN,		/* If connection's congestion control
+					 * needs ECN
+					 */
+	BPF_SOCK_OPS_BASE_RTT,		/* Get base RTT. The correct value is
+					 * based on the path and may be
+					 * dependent on the congestion control
+					 * algorithm. In general it indicates
+					 * a congestion threshold. RTTs above
+					 * this indicate congestion
+					 */
+	BPF_SOCK_OPS_RTO_CB,		/* Called when an RTO has triggered.
+					 * Arg1: value of icsk_retransmits
+					 * Arg2: value of icsk_rto
+					 * Arg3: whether RTO has expired
+					 */
+	BPF_SOCK_OPS_RETRANS_CB,	/* Called when skb is retransmitted.
+					 * Arg1: sequence number of 1st byte
+					 * Arg2: # segments
+					 * Arg3: return value of
+					 *       tcp_transmit_skb (0 => success)
+					 */
+	BPF_SOCK_OPS_STATE_CB,		/* Called when TCP changes state.
+					 * Arg1: old_state
+					 * Arg2: new_state
+					 */
+};
+
+/* List of TCP states. There is a build check in net/ipv4/tcp.c to detect
+ * changes between the TCP and BPF versions. Ideally this should never happen.
+ * If it does, we need to add code to convert them before calling
+ * the BPF sock_ops function.
+ */
+enum {
+	BPF_TCP_ESTABLISHED = 1,
+	BPF_TCP_SYN_SENT,
+	BPF_TCP_SYN_RECV,
+	BPF_TCP_FIN_WAIT1,
+	BPF_TCP_FIN_WAIT2,
+	BPF_TCP_TIME_WAIT,
+	BPF_TCP_CLOSE,
+	BPF_TCP_CLOSE_WAIT,
+	BPF_TCP_LAST_ACK,
+	BPF_TCP_LISTEN,
+	BPF_TCP_CLOSING,	/* Now a valid state */
+	BPF_TCP_NEW_SYN_RECV,
+
+	BPF_TCP_MAX_STATES	/* Leave at the end! */
+};
+
+#define TCP_BPF_IW		1001	/* Set TCP initial congestion window */
+#define TCP_BPF_SNDCWND_CLAMP	1002	/* Set sndcwnd_clamp */
+
+struct bpf_perf_event_value {
+	__u64 counter;
+	__u64 enabled;
+	__u64 running;
+};
+
+#define BPF_DEVCG_ACC_MKNOD	(1ULL << 0)
+#define BPF_DEVCG_ACC_READ	(1ULL << 1)
+#define BPF_DEVCG_ACC_WRITE	(1ULL << 2)
+
+#define BPF_DEVCG_DEV_BLOCK	(1ULL << 0)
+#define BPF_DEVCG_DEV_CHAR	(1ULL << 1)
+
+struct bpf_cgroup_dev_ctx {
+	/* access_type encoded as (BPF_DEVCG_ACC_* << 16) | BPF_DEVCG_DEV_* */
+	__u32 access_type;
+	__u32 major;
+	__u32 minor;
+};
+
+struct bpf_raw_tracepoint_args {
+	__u64 args[0];
 };
 
 #endif /* _UAPI__LINUX_BPF_H__ */

--- a/vendor/github.com/iovisor/gobpf/elf/include/bpf_map.h
+++ b/vendor/github.com/iovisor/gobpf/elf/include/bpf_map.h
@@ -1,0 +1,18 @@
+#define BUF_SIZE_MAP_NS 256
+
+typedef struct bpf_map_def {
+	unsigned int type;
+	unsigned int key_size;
+	unsigned int value_size;
+	unsigned int max_entries;
+	unsigned int map_flags;
+	unsigned int pinning;
+	char namespace[BUF_SIZE_MAP_NS];
+} bpf_map_def;
+
+enum bpf_pin_type {
+	PIN_NONE = 0,
+	PIN_OBJECT_NS,
+	PIN_GLOBAL_NS,
+	PIN_CUSTOM_NS,
+};

--- a/vendor/github.com/iovisor/gobpf/elf/pinning.go
+++ b/vendor/github.com/iovisor/gobpf/elf/pinning.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"unsafe"
 
 	"github.com/iovisor/gobpf/pkg/bpffs"
@@ -36,7 +37,15 @@ const (
 	BPFFSPath     = "/sys/fs/bpf/"
 )
 
-func pinObject(fd int, namespace, object, name string) error {
+func validPinPath(PinPath string) bool {
+	if !strings.HasPrefix(PinPath, BPFFSPath) {
+		return false
+	}
+
+	return filepath.Clean(PinPath) == PinPath
+}
+
+func pinObject(fd int, pinPath string) error {
 	mounted, err := bpffs.IsMounted()
 	if err != nil {
 		return fmt.Errorf("error checking if %q is mounted: %v", BPFFSPath, err)
@@ -44,26 +53,37 @@ func pinObject(fd int, namespace, object, name string) error {
 	if !mounted {
 		return fmt.Errorf("bpf fs not mounted at %q", BPFFSPath)
 	}
-	mapPath := filepath.Join(BPFFSPath, namespace, object, name)
-	err = os.MkdirAll(filepath.Dir(mapPath), 0755)
+	err = os.MkdirAll(filepath.Dir(pinPath), 0755)
 	if err != nil {
-		return fmt.Errorf("error creating map directory %q: %v", filepath.Dir(mapPath), err)
+		return fmt.Errorf("error creating directory %q: %v", filepath.Dir(pinPath), err)
 	}
-	err = os.RemoveAll(mapPath)
-	if err != nil {
-		return fmt.Errorf("error removing old map file %q: %v", mapPath, err)
+	_, err = os.Stat(pinPath)
+	if err == nil {
+		return fmt.Errorf("aborting, found file at %q: %v", pinPath, err)
 	}
-
-	mapPathC := C.CString(mapPath)
-	defer C.free(unsafe.Pointer(mapPathC))
-
-	ret, err := C.bpf_pin_object(C.int(fd), mapPathC)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat %q: %v", pinPath, err)
+	}
+	pinPathC := C.CString(pinPath)
+	defer C.free(unsafe.Pointer(pinPathC))
+	ret, err := C.bpf_pin_object(C.int(fd), pinPathC)
 	if ret != 0 {
-		return fmt.Errorf("error pinning object to %q: %v", mapPath, err)
+		return fmt.Errorf("error pinning object to %q: %v", pinPath, err)
 	}
 	return nil
 }
 
+// PinObjectGlobal pins and object to a name in a namespaces
+// e.g. `/sys/fs/bpf/my-namespace/globals/my-name`
 func PinObjectGlobal(fd int, namespace, name string) error {
-	return pinObject(fd, namespace, BPFDirGlobals, name)
+	pinPath := filepath.Join(BPFFSPath, namespace, BPFDirGlobals, name)
+	return pinObject(fd, pinPath)
+}
+
+// PinObject pins an object to a path
+func PinObject(fd int, pinPath string) error {
+	if !validPinPath(pinPath) {
+		return fmt.Errorf("not a valid pin path: %s", pinPath)
+	}
+	return pinObject(fd, pinPath)
 }

--- a/vendor/github.com/iovisor/gobpf/pkg/bpffs/fs.go
+++ b/vendor/github.com/iovisor/gobpf/pkg/bpffs/fs.go
@@ -19,26 +19,36 @@ func init() {
 	FsMagicBPFFS = *(*int32)(unsafe.Pointer(&magic))
 }
 
-// IsMounted checks if the BPF fs is mounted already
-func IsMounted() (bool, error) {
+// IsMountedAt checks if the BPF fs is mounted already in the custom location
+func IsMountedAt(mountpoint string) (bool, error) {
 	var data syscall.Statfs_t
-	if err := syscall.Statfs(BPFFSPath, &data); err != nil {
-		return false, fmt.Errorf("cannot statfs %q: %v", BPFFSPath, err)
+	if err := syscall.Statfs(mountpoint, &data); err != nil {
+		return false, fmt.Errorf("cannot statfs %q: %v", mountpoint, err)
 	}
 	return int32(data.Type) == FsMagicBPFFS, nil
 }
 
-// Mount mounts the BPF fs if not already mounted
-func Mount() error {
-	mounted, err := IsMounted()
+// IsMounted checks if the BPF fs is mounted already in the default location
+func IsMounted() (bool, error) {
+	return IsMountedAt(BPFFSPath)
+}
+
+// MountAt mounts the BPF fs in the custom location (if not already mounted)
+func MountAt(mountpoint string) error {
+	mounted, err := IsMountedAt(mountpoint)
 	if err != nil {
 		return err
 	}
 	if mounted {
 		return nil
 	}
-	if err := syscall.Mount(BPFFSPath, BPFFSPath, "bpf", 0, ""); err != nil {
-		return fmt.Errorf("error mounting %q: %v", BPFFSPath, err)
+	if err := syscall.Mount(mountpoint, mountpoint, "bpf", 0, ""); err != nil {
+		return fmt.Errorf("error mounting %q: %v", mountpoint, err)
 	}
 	return nil
+}
+
+// Mount mounts the BPF fs in the default location (if not already mounted)
+func Mount() error {
+	return MountAt(BPFFSPath)
 }

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -5,7 +5,7 @@
 			"importpath": "github.com/iovisor/gobpf/elf",
 			"repository": "https://github.com/iovisor/gobpf",
 			"vcs": "git",
-			"revision": "f53889884f5cb2c5c3c644a56467002232d208e9",
+			"revision": "4ece6c56f93637c86338885d37e98ff0fb97b4c9",
 			"branch": "master",
 			"path": "/elf",
 			"notests": true
@@ -14,7 +14,7 @@
 			"importpath": "github.com/iovisor/gobpf/pkg/bpffs",
 			"repository": "https://github.com/iovisor/gobpf",
 			"vcs": "git",
-			"revision": "f53889884f5cb2c5c3c644a56467002232d208e9",
+			"revision": "4ece6c56f93637c86338885d37e98ff0fb97b4c9",
 			"branch": "master",
 			"path": "/pkg/bpffs",
 			"notests": true
@@ -23,7 +23,7 @@
 			"importpath": "github.com/iovisor/gobpf/pkg/cpuonline",
 			"repository": "https://github.com/iovisor/gobpf",
 			"vcs": "git",
-			"revision": "f53889884f5cb2c5c3c644a56467002232d208e9",
+			"revision": "4ece6c56f93637c86338885d37e98ff0fb97b4c9",
 			"branch": "master",
 			"path": "/pkg/cpuonline",
 			"notests": true


### PR DESCRIPTION
I updated the vendored bits from `gobpf` in order to pull in the latest, https://github.com/iovisor/gobpf/pull/139 in particular (which brings more clarity in terms of licensing). For the update, I ran
```sh
$  gvt update github.com/iovisor/gobpf/elf
$  gvt update github.com/iovisor/gobpf/pkg/bpffs
$  gvt update github.com/iovisor/gobpf/pkg/cpuonline
```

A local test-build still passes. I wasn't quite sure how else to test this.