### PR TITLE
Add an offset to all timestamps

### DIFF
--- a/pkg/tracer/event.go
+++ b/pkg/tracer/event.go
@@ -39,9 +39,15 @@ func tcpV4ToGo(data *[]byte) (ret TcpV4) {
 	return
 }
 
+// Offset added to all timestamps, to hold back events so they are less
+// likely to be reported out of order. Value is in nanoseconds.
+var (
+	TimestampOffset uint64 = 100000
+)
+
 func tcpV4Timestamp(data *[]byte) uint64 {
 	eventC := (*C.struct_tcp_ipv4_event_t)(unsafe.Pointer(&(*data)[0]))
-	return uint64(eventC.timestamp)
+	return uint64(eventC.timestamp) + TimestampOffset
 }
 
 func tcpV6ToGo(data *[]byte) (ret TcpV6) {
@@ -74,5 +80,5 @@ func tcpV6ToGo(data *[]byte) (ret TcpV6) {
 
 func tcpV6Timestamp(data *[]byte) uint64 {
 	eventC := (*C.struct_tcp_ipv6_event_t)(unsafe.Pointer(&(*data)[0]))
-	return uint64(eventC.timestamp)
+	return uint64(eventC.timestamp) + TimestampOffset
 }


### PR DESCRIPTION
This is attempting to correct an issue noted at https://github.com/iovisor/gobpf/issues/42

The timestamps we compute are compared against the time that `poll()` returned, in [perf.go](https://github.com/iovisor/gobpf/blob/master/elf/perf.go).  By adding an offset we cause iovisor to hold back some events until a later poll, which means they are less likely to be reported out of order.
